### PR TITLE
add vars for include path and libs for f2837xd driverlib

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+<!-- 
+
+1. In one sentence, or as close as possible, summarize why the changes are
+needed. Then, include any relevant links, such as Slack discussions or design
+documents. 
+
+2. In one sentence, or as close as possible, summarize how the changes achieve
+the resolution of the issue.
+
+3. Specify the number of the issue resolved by this PR below.
+
+-->
+
+- resolves #
+
+## Details
+<!-- 
+
+Describe the specific changes that have been made in this pull request. Provide
+details on the approach taken to address the problem and any notable
+implementation details. 
+
+If the changes have visual elements or supporting visuals, like a change to a
+user interface or images of signals on a scope, including screenshots or GIFs
+can help reviewers understand them more easily. 
+
+Also include any additional information that might be needed for verification
+and validation.
+
+-->
+
+## Testing
+<!--
+
+Describe how the changes have been tested and how to reproduce the test results.
+
+If no tests or testing is necessary, briefly state why.
+
+-->
+
+## Checklist
+
+- [ ] I have added or updated doc comments for my code changes.
+- [ ] I have added or updated comments to difficult-to-understand code.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] My changes generate no new warnings or errors.

--- a/meson.build
+++ b/meson.build
@@ -2,4 +2,10 @@ project('c2000ware-core-sdk', 'c',
   version: '5.03.00.00',
 )
 
-c2000ware_path = meson.current_source_dir()
+# Includes and libs for driverlib.lib for the F2837xd.
+#  
+f2837xd_driverlib_include = include_directories('driverlib' / 'f2837xd' / 'driverlib')
+f2837xd_driverlib_debug_path = meson.current_source_dir() / 'driverlib' / 'f2837xd' / 'driverlib' / 'ccs' / 'Debug' / 'driverlib.lib'
+f2837xd_driverlib_debug_lib =  files(f2837xd_driverlib_debug_path)
+f2837xd_driverlib_release_path = meson.current_source_dir() / 'driverlib' / 'f2837xd' / 'driverlib' / 'ccs' / 'Release' / 'driverlib.lib'
+f2837xd_driverlib_release_lib = files(f2837xd_driverlib_release_path)


### PR DESCRIPTION
## Summary
<!-- 

1. In one sentence, or as close as possible, summarize why the changes are
needed. Then, include any relevant links, such as Slack discussions or design
documents. 

2. In one sentence, or as close as possible, summarize how the changes achieve
the resolution of the issue.

3. Specify the number of the issue resolved by this PR below.

-->

No variables were defined in the Meson module to access driverlib for the F2837xd.

Variable have been added to provide access to driverlib for the F2837xd in including projects.

- resolves #3 

A PR template was also been added.

## Details
<!-- 

Describe the specific changes that have been made in this pull request. Provide
details on the approach taken to address the problem and any notable
implementation details. 

If the changes have visual elements or supporting visuals, like a change to a
user interface or images of signals on a scope, including screenshots or GIFs
can help reviewers understand them more easily. 

Also include any additional information that might be needed for verification
and validation.

-->

No additional details.

## Testing
<!--

Describe how the changes have been tested and how to reproduce the test results.

If no tests or testing is necessary, briefly state why.

-->

No changes have been made that need tests.

## Checklist

- [x] I have added or updated doc comments for my code changes.
- [x] I have added or updated comments to difficult-to-understand code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors.
